### PR TITLE
Fix non-image files causing unhandled exception on upload

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,91 +1,106 @@
 'use strict';
 
-/**
- * Module dependencies
- */
-
-// Public node modules.
 const fs = require('fs');
 const path = require('path');
-var Jimp = require('jimp');
+const Jimp = require('jimp');
+const ImageType = require('image-type');
 
+/**
+ * Local Resize Upload Provider
+ * Saves uploads to localhost with configured resized images
+ */
 module.exports = {
-  provider: 'local-resize',
-  name: 'Local upload resize',
-  init: (config) => {
-    return {
-      upload: (file) => {
-        return new Promise((resolve, reject) => {
-           //resize function
-           function resize(file,variant){
-              return Jimp.read(file.buffer)
-              .then(image => {
-                //largest
-                let destImg = path.join(strapi.config.appPath, 'public', `uploads/${variant.prefix}${file.hash}${file.ext}`)
-                //change to preferences https://www.npmjs.com/package/jimp
-                if(variant.scaleType!=="resize"){
-                  //cover image
-                  image.cover(variant.maxSize,variant.maxSize)
-                }else{
-                  //width, height
-                  image.resize(Jimp.AUTO, variant.maxSize)
-                }
-                image.quality(variant.quality) 
-                image.write(destImg)
-                file[variant.attributes] = `/uploads/${variant.prefix}${file.hash}${file.ext}`;
-                return true
-              })
-              .catch(err => {
-                return reject(err);
-              });
-          }
-          //define variants, props should be defined in plugins/uploads/models/File.settings.json
-          let variants = [
-          {
-              maxSize:900,
-              scaleType:"resize",
-              prefix:"large_",
-              quality:70,
-              attributes:'url'
-          },
-          {
-              maxSize:600,
-              scaleType:"cover",
-              prefix:"thumb_",
-              quality:70,
-              attributes:'thumb'
-          }
-          ]
-          //resize image in two variants
-          var promise = resize(file,variants[0]);
-          promise
-          .then(function() {
-            return resize(file,variants[1]);
-          })
-          .then(function() {
-            return resolve()
-          })
-          .catch(err => {
-            return reject(err);
-          });
-        });
-      },
-      delete: (file) => {
-        return new Promise((resolve, reject) => {
-          const filePath = path.join(strapi.config.appPath, 'public', `uploads/baander${file.hash}${file.ext}`);
+    provider: 'local-resize',
+    name: 'Local upload resize',
 
-          if (!fs.existsSync(filePath)) {
-            return resolve('File doesn\'t exist');
-          }
-          // remove file from public/assets folder
-          fs.unlink(filePath, (err) => {
-            if (err) {
-              return reject(err);
+    init: () => {
+        return {
+            /**
+             * Upload
+             * @param file
+             * @returns {Promise<unknown>}
+             */
+            upload: (file) => {
+                return new Promise((resolve, reject) => {
+                    function resize(file, variant) {
+                        return Jimp.read(file.buffer)
+                            .then(image => {
+                                let destImg = path.join(strapi.config.appPath, 'public', `uploads/${variant.prefix}${file.hash}${file.ext}`);
+                                if (variant.scaleType !== "resize") {
+                                    image.cover(variant.maxSize, variant.maxSize)
+                                } else {
+                                    image.resize(Jimp.AUTO, variant.maxSize)
+                                }
+                                image.quality(variant.quality);
+                                image.write(destImg);
+                                file[variant.attributes] = `/uploads/${variant.prefix}${file.hash}${file.ext}`;
+                                return true
+                            })
+                            .catch(err => {
+                                return reject(err);
+                            });
+                    }
+
+                    // define variants, props should be defined in plugins/uploads/models/File.settings.json
+                    let variants = [
+                        {
+                            maxSize: 1080,
+                            scaleType: "resize",
+                            prefix: "large_",
+                            quality: 70,
+                            attributes: 'url'
+                        },
+                        {
+                            maxSize: 400,
+                            scaleType: "cover",
+                            prefix: "thumb_",
+                            quality: 70,
+                            attributes: 'thumb'
+                        }
+                    ];
+
+                    // skip resizing if file is not an image
+                    if (!ImageType(file.buffer)) {
+                        file.url = `/uploads/${file.hash}${file.ext}`;
+                        return resolve();
+                    }
+
+                    // resize the images
+                    const promise = resize(file, variants[0]);
+                    promise
+                        .then(function () {
+                            return resize(file, variants[1]);
+                        })
+                        .then(function () {
+                            return resolve()
+                        })
+                        .catch(err => {
+                            return reject(err);
+                        });
+                });
+            },
+
+            /**
+             * Delete
+             * @param file
+             * @returns {Promise<unknown>}
+             */
+            delete: (file) => {
+                return new Promise((resolve, reject) => {
+                    const filePath = path.join(strapi.config.appPath, 'public', `uploads/baander${file.hash}${file.ext}`);
+
+                    if (!fs.existsSync(filePath)) {
+                        return resolve('File doesn\'t exist');
+                    }
+                    // remove file from public/assets folder
+                    fs.unlink(filePath, (err) => {
+                        if (err) {
+                            return reject(err);
+                        }
+                        resolve();
+                    });
+                });
             }
-            resolve();
-          });
-        });
-      }
+        }
     }
-  }
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
-  "name": "strapi-upload-local-variants",
-  "version": "3.0.0-alpha.11",
+  "name": "strapi-provider-upload-local-resize",
+  "version": "0.0.31",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -362,6 +362,21 @@
       "version": "1.1.12",
       "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.12.tgz",
       "integrity": "sha512-GguP+DRY+pJ3soyIiGPTvdiVXjZ+DbXOxGpXn3eMvNW4x4irjqXm4wHKscC+TfxSJ0yw/S1F24tqdMNsMZTiLA=="
+    },
+    "image-type": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/image-type/-/image-type-4.1.0.tgz",
+      "integrity": "sha512-CFJMJ8QK8lJvRlTCEgarL4ro6hfDQKif2HjSvYCdQZESaIPV4v9imrf7BQHK+sQeTeNeMpWciR9hyC/g8ybXEg==",
+      "requires": {
+        "file-type": "^10.10.0"
+      },
+      "dependencies": {
+        "file-type": {
+          "version": "10.11.0",
+          "resolved": "https://registry.npmjs.org/file-type/-/file-type-10.11.0.tgz",
+          "integrity": "sha512-uzk64HRpUZyTGZtVuvrjP0FYxzQrBf4rojot6J65YMEbwBLB0CWm0CLojVpwpmFmxcE/lkvYICgfcGozbBq6rw=="
+        }
+      }
     },
     "is-callable": {
       "version": "1.1.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "bundleDependencies": false,
   "dependencies": {
+    "image-type": "^4.1.0",
     "jimp": "^0.6.0"
   },
   "deprecated": false,


### PR DESCRIPTION
I've included an extra library image-type to determine the image type of uploads, and added a check to skip the image resizing if an upload is not an image.